### PR TITLE
Rawencoding validation fix

### DIFF
--- a/src/Spryng/Api/Utilities/Validator.php
+++ b/src/Spryng/Api/Utilities/Validator.php
@@ -80,10 +80,11 @@ class Validator
         
         if ( isset($options['rawencoding']) )
         {
-            if ( gettype($options) != "boolean" )
+            $enc = $options['rawencoding'];
+            if ($enc !== true && $enc !== false && $enc !== 0 && $enc !== 1)
             {
                 throw new InvalidRequestException(
-                    "rawencoding option has to be instantiated as a boolean",
+                    "Invalid value for 'rawencoding' parameter.",
                     100
                 );
             }


### PR DESCRIPTION
Previously validated if the entirety of `$options` is a boolean. `$options` is an array. Also allow '0' or '1' as value for `$options['rawencoding']`.